### PR TITLE
Call `ControllerUnpublishVolume` if a `Node` is gone

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -213,6 +213,17 @@ func (d *driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 
 func (d *driver) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	d.log.Info("Unpublishing volume from node", "Volume", req.GetVolumeId(), "Node", req.GetNodeId())
+
+	node := &corev1.Node{}
+	nodeKey := client.ObjectKey{Name: req.GetNodeId()}
+	if err := d.targetClient.Get(ctx, nodeKey, node); err != nil {
+		if apierrors.IsNotFound(err) {
+			d.log.Info("Node does not longer exists", "Node", req.GetNodeId())
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
+		return nil, status.Errorf(codes.Internal, "could not get node %s: %w", req.GetNodeId(), err)
+	}
+
 	providerID, err := NodeGetProviderID(ctx, req.GetNodeId(), d.targetClient)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get providerID from node %s: %v", req.GetNodeId(), err)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -97,6 +98,9 @@ func NodeGetProviderID(ctx context.Context, nodeName string, c client.Client) (s
 	node := &corev1.Node{}
 	nodeKey := client.ObjectKey{Name: nodeName}
 	if err := c.Get(ctx, nodeKey, node); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", err
+		}
 		return "", fmt.Errorf("could not get node %s: %w", nodeName, err)
 	}
 

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -167,9 +167,15 @@ var _ = Describe("Driver tests", func() {
 		Expect(publishRes.PublishContext["device_name"]).To(Equal(validateDeviceName(createdVolume, machine, volumeId+"-attachment", d.log)))
 		Expect(publishRes.PublishContext["node_id"]).To(Equal(d.nodeId))
 
-		By("unpublishing the volume")
-		unpublishVolReq := getCrtControllerUnpublishVolumeRequest(volumeId, d.nodeId)
+		By("unpublishing the volume from node no longer exist")
+		unpublishVolReq := getCrtControllerUnpublishVolumeRequest(volumeId, "nodeNotExist")
 		unpublishRes, err := d.ControllerUnpublishVolume(ctx, unpublishVolReq)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(unpublishRes).ShouldNot(BeNil())
+
+		By("unpublishing the volume from existing node")
+		unpublishVolReq = getCrtControllerUnpublishVolumeRequest(volumeId, d.nodeId)
+		unpublishRes, err = d.ControllerUnpublishVolume(ctx, unpublishVolReq)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(unpublishRes).ShouldNot(BeNil())
 


### PR DESCRIPTION
- Fix `ControllerUnpublishVolume` when the machine no longer exists
- Add tests