### PR TITLE
Refactor driver name handling and topology keys

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ var scheme = runtime.NewScheme()
 var (
 	targetKubeconfig  string
 	onmetalKubeconfig string
+	driverName        string
 )
 
 func init() {
@@ -50,6 +51,7 @@ func init() {
 
 	flag.StringVar(&targetKubeconfig, "target-kubeconfig", "", "Path pointing to the target kubeconfig.")
 	flag.StringVar(&onmetalKubeconfig, "onmetal-kubeconfig", "", "Path pointing to the onmetal kubeconfig.")
+	flag.StringVar(&driverName, "driver-name", driver.CSIDriverName, "Override the default driver name.")
 	flag.Parse()
 }
 
@@ -76,11 +78,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	drv := driver.NewDriver(config, targetClient, onMetalClient)
+	drv := driver.NewDriver(config, targetClient, onMetalClient, driverName)
 	gocsi.Run(
 		ctx,
-		driver.CSIDriverName,
-		"onMetal CSI Driver Plugin",
+		driverName,
+		"onmetal CSI Driver Plugin",
 		"",
 		&gocsi.StoragePlugin{
 			Controller:  drv,

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -33,7 +33,7 @@ const (
 	ParameterVolumeID = "volume_id"
 	// ParameterVolumeName is the volume name parameter
 	ParameterVolumeName = "volume_name"
-	// ParameterCreationTime is the creation time paramater
+	// ParameterCreationTime is the creation time parameter
 	ParameterCreationTime = "creation_time"
 	// ParameterNodeID is the node id parameter
 	ParameterNodeID = "node_id"

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -34,6 +34,7 @@ type driver struct {
 	targetClient  client.Client
 	onmetalClient client.Client
 	config        *options.Config
+	name          string
 }
 
 // Driver is the CSI Mock driver provider.
@@ -45,13 +46,14 @@ type Driver interface {
 	BeforeServe(context.Context, *gocsi.StoragePlugin, net.Listener) error
 }
 
-func NewDriver(config *options.Config, targetClient, onMetalClient client.Client) Driver {
-	klog.InfoS("Driver Information", "Driver", CSIDriverName, "Version", Version())
+func NewDriver(config *options.Config, targetClient, onMetalClient client.Client, driverName string) Driver {
+	klog.InfoS("Driver Information", "Driver", driverName, "Version", Version())
 	nodeMounter, err := mount.NewNodeMounter()
 	if err != nil {
 		panic(fmt.Errorf("error creating node mounter: %w", err))
 	}
 	return &driver{
+		name:          driverName,
 		config:        config,
 		targetClient:  targetClient,
 		onmetalClient: onMetalClient,

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -24,7 +24,7 @@ import (
 func (d *driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	klog.V(6).InfoS("GetPluginInfo: called", "args", *req)
 	return &csi.GetPluginInfoResponse{
-		Name:          CSIDriverName,
+		Name:          d.name,
 		VendorVersion: Version(),
 	}, nil
 }

--- a/pkg/driver/suite_test.go
+++ b/pkg/driver/suite_test.go
@@ -133,7 +133,7 @@ func SetupTest(ctx context.Context) (*corev1.Namespace, *driver) {
 			NodeName:        "node",
 			DriverNamespace: ns.Name,
 		}
-		newDriver := NewDriver(config, k8sClient, k8sClient)
+		newDriver := NewDriver(config, k8sClient, k8sClient, CSIDriverName)
 		*d = *newDriver.(*driver)
 
 		machineClass := &computev1alpha1.MachineClass{


### PR DESCRIPTION
# Proposed Changes

- Add a new flag `driver-name` to override the default driver name
- Change `Name` field in `GetPluginInfoResponse` to use the passed `driverName`

/cc @FlorinPeter 
