### PR TITLE
Implement `NodeGetVolumeStats` in node driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ GOMOD=$(GOCMD) mod
 BINARY_NAME=onmetal-csi-driver
 DOCKER_IMAGE=onmetal-csi-driver
 
+BUILDARGS ?=
+
 # For Development Build #################################################################
 # Docker.io username and tag
 DOCKER_USER=onmetal
@@ -109,7 +111,7 @@ build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_NAME) -v ./cmd/
 
 docker-build: 
-	docker build -t ${IMG} -f Dockerfile .
+	docker build $(BUILDARGS) -t ${IMG} -f Dockerfile .
 
 docker-push:
 	docker push ${IMG}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.6
 	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338
+	golang.org/x/sys v0.8.0
 	google.golang.org/grpc v1.55.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
@@ -84,7 +85,6 @@ require (
 	go4.org/netipx v0.0.0-20220812043211-3cc044ffd68d // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.6.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	utilpath "k8s.io/utils/path"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/onmetal/onmetal-csi-driver/pkg/utils/mount"
@@ -36,6 +37,7 @@ var (
 	nodeCaps = []csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 	}
 )
 
@@ -290,8 +292,37 @@ func (d *driver) getBlockSizeBytes(devicePath string) (int64, error) {
 	return size, nil
 }
 
-func (d *driver) NodeGetVolumeStats(_ context.Context, _ *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "Method NodeGetVolumeStats not implemented")
+func (d *driver) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	klog.InfoS("NodeGetVolumeStats", "Volume", req.GetVolumeId())
+
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "Volume Id not provided")
+	}
+
+	volumePath := req.GetVolumePath()
+	if len(volumePath) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "Volume path not provided")
+	}
+
+	exists, err := d.os.Exists(utilpath.CheckFollowSymlink, req.VolumePath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to check whether volumePath exists: %s", err)
+	}
+	if !exists {
+		return nil, status.Errorf(codes.NotFound, "target: %s not found", volumePath)
+	}
+	stats, err := d.GetDeviceStats(volumePath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get stats by path: %s", err)
+	}
+
+	return &csi.NodeGetVolumeStatsResponse{
+		Usage: []*csi.VolumeUsage{
+			{Total: stats.TotalBytes, Available: stats.AvailableBytes, Used: stats.UsedBytes, Unit: csi.VolumeUsage_BYTES},
+			{Total: stats.TotalInodes, Available: stats.AvailableInodes, Used: stats.UsedInodes, Unit: csi.VolumeUsage_INODES},
+		},
+	}, nil
 }
 
 func (d *driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
@@ -352,7 +383,7 @@ func (d *driver) GetMountDeviceName(mountPath string) (device string, err error)
 
 func (d *driver) GetDeviceStats(path string) (*mount.DeviceStats, error) {
 	var statfs unix.Statfs_t
-	err := unix.Statfs(path, &statfs)
+	err := d.os.Statfs(path, &statfs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -554,17 +554,12 @@ var _ = Describe("Node", func() {
 	})
 
 	Describe("NodeGetVolumeStats", func() {
-		var (
-			req               *csi.NodeGetVolumeStatsRequest
-			stagingTargetPath string
-		)
+		var req *csi.NodeGetVolumeStatsRequest
 
 		BeforeEach(func() {
-			stagingTargetPath = "/target/path/"
 			req = &csi.NodeGetVolumeStatsRequest{
-				VolumeId:          volumeId,
-				StagingTargetPath: stagingTargetPath,
-				VolumePath:        "/volume/path",
+				VolumeId:   volumeId,
+				VolumePath: "/volume/path",
 			}
 		})
 
@@ -598,7 +593,7 @@ var _ = Describe("Node", func() {
 			Expect(statusErr.Code()).To(Equal(codes.InvalidArgument))
 		})
 
-		It("should fail if check if GetDeviceStats fails", func() {
+		It("should fail if check GetDeviceStats fails", func() {
 			mockOS.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(true, nil)
 			mockOS.EXPECT().Statfs(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			_, err := drv.NodeGetVolumeStats(ctx, req)

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -611,6 +611,22 @@ var _ = Describe("Node", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(SatisfyAll(
 				HaveField("Usage", Not(BeNil())),
+				HaveField("Usage", ContainElements([]*csi.VolumeUsage{
+
+					{
+						Available: 0,
+						Total:     0,
+						Used:      0,
+						Unit:      1,
+					},
+					{
+						Available: 0,
+						Total:     0,
+						Used:      0,
+						Unit:      2,
+					},
+				},
+				)),
 			))
 		})
 

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -610,7 +610,6 @@ var _ = Describe("Node", func() {
 			res, err := drv.NodeGetVolumeStats(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(SatisfyAll(
-				HaveField("Usage", Not(BeNil())),
 				HaveField("Usage", ContainElements([]*csi.VolumeUsage{
 
 					{

--- a/pkg/utils/mount/mock_mountutils_unix.go
+++ b/pkg/utils/mount/mock_mountutils_unix.go
@@ -13,7 +13,7 @@ import (
 
 // MockMountWrapper is a mock of MountWrapper interface.
 type MockMountWrapper struct {
-	mount_utils.Interface
+    mount_utils.Interface
 	ctrl     *gomock.Controller
 	recorder *MockMountWrapperMockRecorder
 }

--- a/pkg/utils/mount/mock_mountutils_unix.go
+++ b/pkg/utils/mount/mock_mountutils_unix.go
@@ -13,7 +13,7 @@ import (
 
 // MockMountWrapper is a mock of MountWrapper interface.
 type MockMountWrapper struct {
-    mount_utils.Interface
+	mount_utils.Interface
 	ctrl     *gomock.Controller
 	recorder *MockMountWrapperMockRecorder
 }

--- a/pkg/utils/mount/mount.go
+++ b/pkg/utils/mount/mount.go
@@ -1,0 +1,10 @@
+package mount
+
+type DeviceStats struct {
+	AvailableBytes  int64
+	TotalBytes      int64
+	UsedBytes       int64
+	AvailableInodes int64
+	TotalInodes     int64
+	UsedInodes      int64
+}

--- a/pkg/utils/os/mock_osutils_unix.go
+++ b/pkg/utils/os/mock_osutils_unix.go
@@ -9,6 +9,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	unix "golang.org/x/sys/unix"
+	path "k8s.io/utils/path"
 )
 
 // MockOSWrapper is a mock of OSWrapper interface.
@@ -32,6 +34,21 @@ func NewMockOSWrapper(ctrl *gomock.Controller) *MockOSWrapper {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockOSWrapper) EXPECT() *MockOSWrapperMockRecorder {
 	return m.recorder
+}
+
+// Exists mocks base method.
+func (m *MockOSWrapper) Exists(linkBehavior path.LinkTreatment, filename string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", linkBehavior, filename)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Exists indicates an expected call of Exists.
+func (mr *MockOSWrapperMockRecorder) Exists(linkBehavior, filename interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockOSWrapper)(nil).Exists), linkBehavior, filename)
 }
 
 // IsNotExist mocks base method.
@@ -104,4 +121,18 @@ func (m *MockOSWrapper) Stat(name string) (os.FileInfo, error) {
 func (mr *MockOSWrapperMockRecorder) Stat(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockOSWrapper)(nil).Stat), name)
+}
+
+// Statfs mocks base method.
+func (m *MockOSWrapper) Statfs(path string, buf *unix.Statfs_t) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Statfs", path, buf)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Statfs indicates an expected call of Statfs.
+func (mr *MockOSWrapperMockRecorder) Statfs(path, buf interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Statfs", reflect.TypeOf((*MockOSWrapper)(nil).Statfs), path, buf)
 }

--- a/pkg/utils/os/osutils_unix.go
+++ b/pkg/utils/os/osutils_unix.go
@@ -61,8 +61,7 @@ func (o OsOps) Open(path string) (*os.File, error) {
 }
 
 func (o OsOps) Statfs(path string, buf *unix.Statfs_t) (err error) {
-	var statfs unix.Statfs_t
-	return unix.Statfs(path, &statfs)
+	return unix.Statfs(path, buf)
 }
 
 func (o OsOps) Exists(linkBehavior utilpath.LinkTreatment, filename string) (bool, error) {

--- a/pkg/utils/os/osutils_unix.go
+++ b/pkg/utils/os/osutils_unix.go
@@ -19,6 +19,9 @@ package os
 
 import (
 	"os"
+
+	"golang.org/x/sys/unix"
+	utilpath "k8s.io/utils/path"
 )
 
 //go:generate $MOCKGEN -package os -destination=mock_osutils_unix.go -source osutils_unix.go
@@ -31,6 +34,8 @@ type OSWrapper interface {
 	Stat(name string) (os.FileInfo, error)
 	IsNotExist(err error) bool
 	Open(path string) (*os.File, error)
+	Statfs(path string, buf *unix.Statfs_t) (err error)
+	Exists(linkBehavior utilpath.LinkTreatment, filename string) (bool, error)
 }
 
 type OsOps struct{}
@@ -53,4 +58,13 @@ func (o OsOps) IsNotExist(err error) bool {
 
 func (o OsOps) Open(path string) (*os.File, error) {
 	return os.Open(path)
+}
+
+func (o OsOps) Statfs(path string, buf *unix.Statfs_t) (err error) {
+	var statfs unix.Statfs_t
+	return unix.Statfs(path, &statfs)
+}
+
+func (o OsOps) Exists(linkBehavior utilpath.LinkTreatment, filename string) (bool, error) {
+	return utilpath.Exists(utilpath.CheckFollowSymlink, filename)
 }


### PR DESCRIPTION
# Summary

The `NodeGetVolumeStats` method was previously missing, which prevented the application from collecting volume statistics. This PR implements the method and adds test cases to ensure that it works correctly.

# Proposed Changes

- Implement `NodeGetVolumeStats` method
- Add tests

