### PR TITLE
Change log levels and fix typo in controller and node functions

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -283,7 +283,7 @@ func (d *driver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequ
 }
 
 func (d *driver) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	klog.V(4).InfoS("ControllerExpandVolume: called", "args", *req)
+	klog.InfoS("ControllerExpandVolume: called", "args", *req)
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -324,7 +324,7 @@ func (d *driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 
 	volumeBase := volume.DeepCopy()
 	volume.Spec.Resources[corev1alpha1.ResourceStorage] = *resource.NewQuantity(newVolSize, resource.BinarySI)
-	klog.V(4).InfoS("Patching volume with new volume size", "Volume", client.ObjectKeyFromObject(volume))
+	klog.InfoS("Patching volume with new volume size", "Volume", client.ObjectKeyFromObject(volume))
 	if err := d.onmetalClient.Patch(ctx, volume, client.MergeFrom(volumeBase)); err != nil {
 		return nil, apierrors.NewBadRequest("failed to patch volume with new volume size")
 	}
@@ -335,7 +335,7 @@ func (d *driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 }
 
 func (d *driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	klog.V(4).InfoS("ValidateVolumeCapabilities: called", "args", *req)
+	klog.InfoS("ValidateVolumeCapabilities: called", "args", *req)
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -364,7 +364,7 @@ func (d *driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 }
 
 func (d *driver) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
-	klog.V(4).InfoS("ControllerGetCapabilities: called", "args", *req)
+	klog.InfoS("ControllerGetCapabilities: called", "args", *req)
 	var caps []*csi.ControllerServiceCapability
 	for _, cap := range controllerCaps {
 		c := &csi.ControllerServiceCapability{

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (d *driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
-	klog.V(6).InfoS("GetPluginInfo: called", "args", *req)
+	klog.InfoS("GetPluginInfo: called", "args", *req)
 	return &csi.GetPluginInfoResponse{
 		Name:          d.name,
 		VendorVersion: Version(),
@@ -30,7 +30,7 @@ func (d *driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoReques
 }
 
 func (d *driver) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	klog.V(6).InfoS("GetPluginCapabilities: called", "args", *req)
+	klog.InfoS("GetPluginCapabilities: called", "args", *req)
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -215,7 +215,7 @@ func (d *driver) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVo
 }
 
 func (d *driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-	klog.V(4).InfoS("NodeExpandVolume: called", "args", *req)
+	klog.InfoS("NodeExpandVolume: called", "args", *req)
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -252,7 +252,7 @@ func (d *driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolume
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get device name from mount path %s: %v", volumePath, err)
 	}
-	klog.V(4).InfoS("Device name for volume", "path", volumePath, "name", deviceName)
+	klog.InfoS("Device name for volume", "path", volumePath, "name", deviceName)
 
 	resizefs, err := d.mounter.NewResizeFs()
 	if err != nil {
@@ -271,11 +271,11 @@ func (d *driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolume
 	}
 
 	if diskSizeBytes < reqBytes {
-		// It's possible that the somewhere the volume size was rounded up, getting more size than requested is a success
+		// It's possible that somewhere the volume size was rounded up, getting more size than requested is a success
 		return nil, status.Errorf(codes.Internal, "resize requested for %v but after resize volume was size %v", reqBytes, diskSizeBytes)
 	}
 
-	klog.V(4).InfoS("Expanded volume on node", "volumeID", volumeID, "CapacityBytes", diskSizeBytes)
+	klog.InfoS("Expanded volume on node", "volumeID", volumeID, "CapacityBytes", diskSizeBytes)
 	return &csi.NodeExpandVolumeResponse{CapacityBytes: diskSizeBytes}, nil
 }
 
@@ -343,7 +343,7 @@ func (d *driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 }
 
 func (d *driver) NodeGetCapabilities(_ context.Context, _ *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-	klog.V(4).InfoS("NodeGetCapabilities: called")
+	klog.InfoS("NodeGetCapabilities: called")
 	var caps []*csi.NodeServiceCapability
 	for _, cap := range nodeCaps {
 		c := &csi.NodeServiceCapability{


### PR DESCRIPTION
# Proposed Changes

- Change log level for ControllerExpandVolume, ValidateVolumeCapabilities, ControllerGetCapabilities, GetPluginInfo, and GetPluginCapabilities functions from 4 to Info
- Change log level for NodeExpandVolume and NodeGetCapabilities functions from 4 to Info
- Fix typo in the log message of ControllerExpandVolume function
