### PR TITLE
Improve logging in `ControllerExpandVolume` 

### DIFF
--- a/hack/fix-mountwrapper-mock.sh
+++ b/hack/fix-mountwrapper-mock.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 # Fixes "MountWrapper Type cannot implement 'MountWrapper' as it has a non-exported method and is defined in a different package"
 # See https://github.com/kubernetes/mount-utils/commit/a20fcfb15a701977d086330b47b7efad51eb608e for context.
-sed -i '/type MockMountWrapper struct {/a \    mount_utils.Interface' pkg/utils/mount/mock_mountutils_unix.go
+sed -i '/type MockMountWrapper struct {/a \       mount_utils.Interface' pkg/utils/mount/mock_mountutils_unix.go

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -20,6 +20,9 @@ import (
 )
 
 const (
+	// FSTypeExt4 represents the ext4 filesystem type
+	FSTypeExt4 = "ext4"
+
 	// DefaultVolumeSize represents the default volume size.
 	DefaultVolumeSize int64 = 10 * utils.GiB
 

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -591,7 +591,7 @@ var _ = Describe("Node", func() {
 			Expect(statusErr.Code()).To(Equal(codes.InvalidArgument))
 		})
 
-		It("should fail if check GetDeviceStats fails", func(ctx SpecContext) {
+		It("should fail if check getDeviceStats fails", func(ctx SpecContext) {
 			mockOS.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(true, nil)
 			mockOS.EXPECT().Statfs(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			_, err := drv.NodeGetVolumeStats(ctx, req)

--- a/pkg/utils/mount/mock_mountutils_unix.go
+++ b/pkg/utils/mount/mock_mountutils_unix.go
@@ -13,7 +13,7 @@ import (
 
 // MockMountWrapper is a mock of MountWrapper interface.
 type MockMountWrapper struct {
-	mount_utils.Interface
+       mount_utils.Interface
 	ctrl     *gomock.Controller
 	recorder *MockMountWrapperMockRecorder
 }

--- a/pkg/utils/mount/mock_mountutils_unix.go
+++ b/pkg/utils/mount/mock_mountutils_unix.go
@@ -13,7 +13,7 @@ import (
 
 // MockMountWrapper is a mock of MountWrapper interface.
 type MockMountWrapper struct {
-    mount_utils.Interface
+	mount_utils.Interface
 	ctrl     *gomock.Controller
 	recorder *MockMountWrapperMockRecorder
 }


### PR DESCRIPTION
# Proposed Changes

- Define a constant `FSTypeExt4` for the ext4 filesystem type
- Use the `FSTypeExt4` constant instead of string literal for `fstype` in `CreateVolume` and `NodePublishVolume`
- Remove unnecessary check for `CapacityRange` in `ControllerExpandVolume`
- Use `fmt.Sprintf` to provide a detailed error message when new volume size is less than existing volume size in `ControllerExpandVolume`
- Rename `GetMountDeviceName` to `getMountDeviceName`
- Rename `GetDeviceStats` to `getDeviceStats`
- Update tests to reflect changes in code
