### PR TITLE
Fix check for limit size in `NodeVolumeExpand` call

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -233,7 +233,7 @@ func (d *driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolume
 	}
 
 	limitBytes := req.CapacityRange.GetLimitBytes()
-	if req.CapacityRange != nil && limitBytes < reqBytes {
+	if req.CapacityRange != nil && limitBytes > 0 && limitBytes < reqBytes {
 		return nil, status.Error(codes.OutOfRange, "requested capacity exceeds maximum limit")
 	}
 


### PR DESCRIPTION
# Proposed Changes

- Correctly handle the upper bound limit size if none is set (= 0)
