### PR TITLE
Replace `gomock` import with `go.uber.org/mock`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ADDLICENSE ?= $(LOCALBIN)/addlicense
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.9.2
 ADDLICENSE_VERSION ?= v1.1.0
-MOCKGEN_VERSION ?= v1.6.0
+MOCKGEN_VERSION ?= v0.2.0
 
 # Go parameters
 GOCMD=go
@@ -38,7 +38,7 @@ DOCKER_IMAGE_TAG=latest
 ifeq ($(env),prod)
 	# For Production
 	# Do not change following values unless change in production version or username
-	#For docker.io  
+	#For docker.io
 	DOCKER_USER=your_docker_user_name
 	DOCKER_IMAGE_TAG=1.1.0
 endif
@@ -88,7 +88,7 @@ clean:
 	rm -f $(BINARY_NAME)
 
 build:
-	$(GOBUILD) -o $(BINARY_NAME) -v  ./cmd/ 
+	$(GOBUILD) -o $(BINARY_NAME) -v  ./cmd/
 
 lint: ## Run golangci-lint against code.
 	golangci-lint run ./...
@@ -110,7 +110,7 @@ moddownload:
 build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_NAME) -v ./cmd/
 
-docker-build: 
+docker-build:
 	docker build $(BUILDARGS) -t ${IMG} -f Dockerfile .
 
 docker-push:
@@ -171,4 +171,4 @@ generate-mocks: mockgen ## Generate code (mocks etc.).
 .PHONY: mockgen
 mockgen: $(MOCKGEN)
 $(MOCKGEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/mockgen || GOBIN=$(LOCALBIN) go install github.com/golang/mock/mockgen@$(MOCKGEN_VERSION)
+	test -s $(LOCALBIN)/mockgen || GOBIN=$(LOCALBIN) go install go.uber.org/mock/mockgen@$(MOCKGEN_VERSION)

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.20
 require (
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/dell/gocsi v1.7.0
-	github.com/golang/mock v1.6.0
 	github.com/onmetal/controller-utils v0.8.0
 	github.com/onmetal/onmetal-api v0.1.2-0.20230530094909-67f87469764c
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.9
+	go.uber.org/mock v0.2.0
 	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338
 	golang.org/x/sys v0.10.0
 	google.golang.org/grpc v1.56.2

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
-github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
-github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -307,6 +305,8 @@ go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/mock v0.2.0 h1:TaP3xedm7JaAgScZO7tlvlKrqT0p7I6OsdGB5YNSMDU=
+go.uber.org/mock v0.2.0/go.mod h1:J0y0rp9L3xiff1+ZBfKxlC1fz2+aO16tw0tsDOixfuM=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
@@ -492,7 +492,6 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.9.3 h1:Gn1I8+64MsuTb/HpH+LmQtNas23LhUVr3rYZ0eKuaMM=
 golang.org/x/tools v0.9.3/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=

--- a/hack/fix-mountwrapper-mock.sh
+++ b/hack/fix-mountwrapper-mock.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 # Fixes "MountWrapper Type cannot implement 'MountWrapper' as it has a non-exported method and is defined in a different package"
 # See https://github.com/kubernetes/mount-utils/commit/a20fcfb15a701977d086330b47b7efad51eb608e for context.
-sed -i '/type MockMountWrapper struct {/a \\tmount_utils.Interface' pkg/utils/mount/mock_mountutils_unix.go
+sed -i '/type MockMountWrapper struct {/a \\tmount.Interface' pkg/utils/mount/mock_mountutils_unix.go

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -20,9 +20,9 @@ import (
 	"os"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	k8smountutils "k8s.io/mount-utils"

--- a/pkg/utils/mount/mock_mountutils_unix.go
+++ b/pkg/utils/mount/mock_mountutils_unix.go
@@ -7,13 +7,13 @@ package mount
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-	mount_utils "k8s.io/mount-utils"
+	gomock "go.uber.org/mock/gomock"
+	mount "k8s.io/mount-utils"
 )
 
 // MockMountWrapper is a mock of MountWrapper interface.
 type MockMountWrapper struct {
-	mount_utils.Interface
+	mount.Interface
 	ctrl     *gomock.Controller
 	recorder *MockMountWrapperMockRecorder
 }
@@ -109,10 +109,10 @@ func (mr *MockMountWrapperMockRecorder) IsMountPoint(file interface{}) *gomock.C
 }
 
 // List mocks base method.
-func (m *MockMountWrapper) List() ([]mount_utils.MountPoint, error) {
+func (m *MockMountWrapper) List() ([]mount.MountPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List")
-	ret0, _ := ret[0].([]mount_utils.MountPoint)
+	ret0, _ := ret[0].([]mount.MountPoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/utils/os/mock_osutils_unix.go
+++ b/pkg/utils/os/mock_osutils_unix.go
@@ -8,7 +8,7 @@ import (
 	os "os"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 	unix "golang.org/x/sys/unix"
 	path "k8s.io/utils/path"
 )


### PR DESCRIPTION
# Proposed Changes

- Update the `MOCKGEN_VERSION` from `v1.6.0` to `v0.2.0` in the `Makefile`
- Update the `github.com/golang/mock` dependency version in `go.mod` to `v0.2.0`
- Update the `github.com/golang/mock/gomock` import to `go.uber.org/mock/gomock` in `pkg/driver/node_test.go`
- Update the `github.com/golang/mock/gomock` import to `go.uber.org/mock/gomock` in `pkg/utils/mount/mock_mountutils_unix.go`
- Update the `github.com/golang/mock/gomock` import to `go.uber.org/mock/gomock` in `pkg/utils/os/mock_osutils_unix.go`
