### PR TITLE
Optimize `Controller` test by adding wait groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,6 @@ vet: ## Run go vet against code.
 
 test: generate-mocks fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
-	go mod tidy
 
 .PHONY: add-license
 add-license: addlicense ## Add license headers to all go files.


### PR DESCRIPTION
# Proposed Changes

- Remove `go mod tidy` command from the Makefile
- Add a `sync.WaitGroup` to the `Controller` test
- Add a goroutine and wait group to the `Controller` test
